### PR TITLE
Updated due to $this error on line 84

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -81,7 +81,7 @@ class MSA_functions
 	function MSA_updateThemeNewBlog($blogID)
 	{
 		$blogInfo = MSA_functions::getBlogInfo($blogID);
-		$this->MSA_addThemeToDB($blogInfo);
+		MSA_functions::MSA_addThemeToDB($blogInfo);
 	}
 	
 	function getBlogTheme($blogID)


### PR DESCRIPTION
 PHP Fatal error: Using $this when not in object context in /nas/content/live/bmadmin/wp-content/plugins/multisite-auditor/functions.php on line 84

for some reason, $this-> was used rather than MSA_functions::

I tested it on my server, and it works.